### PR TITLE
.gitignore(全体)を作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# 環境変数ファイル
+.env
+.env.local
+.env.*.local
+
+# OS/IDE関連
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+
+# ログファイル
+*.log
+logs/
+npm-debug.log*
+yarn-error.log*
+
+# キャッシュ
+.cache/
+*.tsbuildinfo


### PR DESCRIPTION
プロジェクト全体に共通するものを無視 (例: .env や .DS_Store など)。